### PR TITLE
feat: export Fd on TCP/UDP/UnixConn

### DIFF
--- a/tcp_linux.go
+++ b/tcp_linux.go
@@ -5,13 +5,14 @@ package rio
 import (
 	"context"
 	"errors"
-	"github.com/brickingsoft/rio/pkg/liburing/aio"
-	"github.com/brickingsoft/rio/pkg/liburing/aio/sys"
 	"io"
 	"net"
 	"os"
 	"syscall"
 	"time"
+
+	"github.com/brickingsoft/rio/pkg/liburing/aio"
+	"github.com/brickingsoft/rio/pkg/liburing/aio/sys"
 )
 
 // ListenTCP acts like [Listen] for TCP networks.
@@ -507,4 +508,9 @@ func (c *TCPConn) MultipathTCP() (bool, error) {
 	}
 	ok := sys.IsUsingMultipathTCP(c.fd.RegularFileDescriptor())
 	return ok, nil
+}
+
+// Fd returns the underlying file descriptor of the connection.
+func (c *TCPConn) Fd() *aio.Fd {
+	return &c.fd.Fd
 }

--- a/udp_linux.go
+++ b/udp_linux.go
@@ -5,12 +5,13 @@ package rio
 import (
 	"context"
 	"errors"
-	"github.com/brickingsoft/rio/pkg/liburing/aio"
-	"github.com/brickingsoft/rio/pkg/liburing/aio/sys"
 	"net"
 	"net/netip"
 	"reflect"
 	"syscall"
+
+	"github.com/brickingsoft/rio/pkg/liburing/aio"
+	"github.com/brickingsoft/rio/pkg/liburing/aio/sys"
 )
 
 // ListenUDP acts like [ListenPacket] for UDP networks.
@@ -360,4 +361,9 @@ func (c *UDPConn) GetSocketOptInt(level int, optName int) (optValue int, err err
 		return
 	}
 	return
+}
+
+// Fd returns the underlying file descriptor of the connection.
+func (c *UDPConn) Fd() *aio.Fd {
+	return &c.fd.Fd
 }

--- a/unix_linux.go
+++ b/unix_linux.go
@@ -5,14 +5,15 @@ package rio
 import (
 	"context"
 	"errors"
-	"github.com/brickingsoft/rio/pkg/liburing/aio"
-	"golang.org/x/sys/unix"
 	"net"
 	"os"
 	"reflect"
 	"sync"
 	"syscall"
 	"time"
+
+	"github.com/brickingsoft/rio/pkg/liburing/aio"
+	"golang.org/x/sys/unix"
 )
 
 // ListenUnix acts like [Listen] for Unix networks.
@@ -434,4 +435,9 @@ func (c *UnixConn) GetSocketOptInt(level int, optName int) (optValue int, err er
 		return
 	}
 	return
+}
+
+// Fd returns the underlying file descriptor of the connection.
+func (c *UnixConn) Fd() *aio.Fd {
+	return &c.fd.Fd
 }


### PR DESCRIPTION
Make file descriptor public and accessible outside the lib. This allow using net compatible modules in rio and liburing at the same time.

(sorry for the linting, Go extension on vscode auto-formatted)